### PR TITLE
fix: remove layer-3 scroll auto-toggle

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
@@ -56,12 +56,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
-layer_state_t layer_state_set_user(layer_state_t state) {
-    // Auto enable scroll mode when the highest layer is 3
-    keyball_set_scroll_mode(get_highest_layer(state) == 3);
-    return state;
-}
-
 #ifdef OLED_ENABLE
 
 #    include "lib/oledkit/oledkit.h"


### PR DESCRIPTION
Drop the keymap hook that enabled scroll mode whenever the highest layer became 3. The issue is now handled through the existing keymap layout and verified by make.

Closes #18