### PR TITLE
feat: レイヤーごとのLED色設定を追加

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/keyball61.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keyball61.c
@@ -41,8 +41,9 @@ void keyball_on_adjust_layout(keyball_adjust_t v) {
 #ifdef RGBLIGHT_ENABLE
     // adjust RGBLIGHT's clipping and effect ranges
     uint8_t lednum_this = keyball.this_have_ball ? 34 : 37;
-    uint8_t lednum_that = !keyball.that_enable ? 0 : keyball.that_have_ball ? 34 : 37;
+    uint8_t lednum_that = (!keyball.that_enable && is_keyboard_master()) ? 0 : keyball.that_have_ball ? 34 : 37;
     rgblight_set_clipping_range(is_keyboard_left() ? 0 : lednum_that, lednum_this);
     rgblight_set_effect_range(0, lednum_this + lednum_that);
+    rgblight_set();
 #endif
 }

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#    define RGBLIGHT_EFFECT_KNIGHT
 //#    define RGBLIGHT_EFFECT_CHRISTMAS
 #    define RGBLIGHT_EFFECT_STATIC_GRADIENT
+#    define RGBLIGHT_LAYERS
 //#    define RGBLIGHT_EFFECT_RGB_TEST
 //#    define RGBLIGHT_EFFECT_ALTERNATING
 //#    define RGBLIGHT_EFFECT_TWINKLE

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
@@ -56,6 +56,73 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
+#ifdef RGBLIGHT_ENABLE
+
+#define LEDNO_LEFT_TOP 0, 29
+#define LEDNO_RIGHT_TOP 44, 27
+
+#define HSV_CYAN_DARK 128, 255, 48
+#define HSV_RED_DARK 0, 255, 48
+#define HSV_YELLOW_DARK 43, 255, 48
+#define HSV_PURPLE_DARK 192, 192, 48
+
+const rgblight_segment_t PROGMEM my_layer0_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_LEFT_TOP, HSV_CYAN_DARK}
+);
+const rgblight_segment_t PROGMEM my_layer1_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_LEFT_TOP, HSV_RED_DARK}
+);
+const rgblight_segment_t PROGMEM my_layer2_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_LEFT_TOP, HSV_YELLOW_DARK}
+);
+const rgblight_segment_t PROGMEM my_layer3_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_LEFT_TOP, HSV_PURPLE_DARK}
+);
+
+const rgblight_segment_t PROGMEM my_layer0_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_RIGHT_TOP, HSV_CYAN_DARK}
+);
+const rgblight_segment_t PROGMEM my_layer1_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_RIGHT_TOP, HSV_RED_DARK}
+);
+const rgblight_segment_t PROGMEM my_layer2_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_RIGHT_TOP, HSV_YELLOW_DARK}
+);
+const rgblight_segment_t PROGMEM my_layer3_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+    {LEDNO_RIGHT_TOP, HSV_PURPLE_DARK}
+);
+
+const rgblight_segment_t* const PROGMEM my_rgb_layers[] = RGBLIGHT_LAYERS_LIST(
+    my_layer0_layer_l,
+    my_layer1_layer_l,
+    my_layer2_layer_l,
+    my_layer3_layer_l,
+    my_layer0_layer_r,
+    my_layer1_layer_r,
+    my_layer2_layer_r,
+    my_layer3_layer_r
+);
+
+void keyboard_post_init_user(void) {
+    rgblight_layers = my_rgb_layers;
+    rgblight_set_layer_state(0, true);
+    rgblight_set_layer_state(4, true);
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    rgblight_set_layer_state(0, layer_state_cmp(state, 0));
+    rgblight_set_layer_state(1, layer_state_cmp(state, 1));
+    rgblight_set_layer_state(2, layer_state_cmp(state, 2));
+    rgblight_set_layer_state(3, layer_state_cmp(state, 3));
+    rgblight_set_layer_state(4, layer_state_cmp(state, 0));
+    rgblight_set_layer_state(5, layer_state_cmp(state, 1));
+    rgblight_set_layer_state(6, layer_state_cmp(state, 2));
+    rgblight_set_layer_state(7, layer_state_cmp(state, 3));
+    return state;
+}
+
+#endif
+
 #ifdef OLED_ENABLE
 
 #    include "lib/oledkit/oledkit.h"

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
@@ -56,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
-#ifdef RGBLIGHT_ENABLE
+#ifdef RGBLIGHT_LAYERS
 
 #define LEDNO_LEFT_TOP 0, 29
 #define LEDNO_RIGHT_TOP 44, 27
@@ -109,7 +109,10 @@ void keyboard_post_init_user(void) {
     rgblight_set_layer_state(4, true);
 }
 
+#endif
+
 layer_state_t layer_state_set_user(layer_state_t state) {
+#ifdef RGBLIGHT_LAYERS
     rgblight_set_layer_state(0, layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, layer_state_cmp(state, 2));
@@ -118,10 +121,9 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     rgblight_set_layer_state(5, layer_state_cmp(state, 1));
     rgblight_set_layer_state(6, layer_state_cmp(state, 2));
     rgblight_set_layer_state(7, layer_state_cmp(state, 3));
+#endif
     return state;
 }
-
-#endif
 
 #ifdef OLED_ENABLE
 

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/keymap.c
@@ -66,45 +66,45 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 #define HSV_YELLOW_DARK 43, 255, 48
 #define HSV_PURPLE_DARK 192, 192, 48
 
-const rgblight_segment_t PROGMEM my_layer0_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer0_left_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_LEFT_TOP, HSV_CYAN_DARK}
 );
-const rgblight_segment_t PROGMEM my_layer1_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer1_left_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_LEFT_TOP, HSV_RED_DARK}
 );
-const rgblight_segment_t PROGMEM my_layer2_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer2_left_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_LEFT_TOP, HSV_YELLOW_DARK}
 );
-const rgblight_segment_t PROGMEM my_layer3_layer_l[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer3_left_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_LEFT_TOP, HSV_PURPLE_DARK}
 );
 
-const rgblight_segment_t PROGMEM my_layer0_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer0_right_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_RIGHT_TOP, HSV_CYAN_DARK}
 );
-const rgblight_segment_t PROGMEM my_layer1_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer1_right_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_RIGHT_TOP, HSV_RED_DARK}
 );
-const rgblight_segment_t PROGMEM my_layer2_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer2_right_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_RIGHT_TOP, HSV_YELLOW_DARK}
 );
-const rgblight_segment_t PROGMEM my_layer3_layer_r[] = RGBLIGHT_LAYER_SEGMENTS(
+const rgblight_segment_t PROGMEM layer3_right_top[] = RGBLIGHT_LAYER_SEGMENTS(
     {LEDNO_RIGHT_TOP, HSV_PURPLE_DARK}
 );
 
-const rgblight_segment_t* const PROGMEM my_rgb_layers[] = RGBLIGHT_LAYERS_LIST(
-    my_layer0_layer_l,
-    my_layer1_layer_l,
-    my_layer2_layer_l,
-    my_layer3_layer_l,
-    my_layer0_layer_r,
-    my_layer1_layer_r,
-    my_layer2_layer_r,
-    my_layer3_layer_r
+const rgblight_segment_t* const PROGMEM layer_leds[] = RGBLIGHT_LAYERS_LIST(
+    layer0_left_top,
+    layer1_left_top,
+    layer2_left_top,
+    layer3_left_top,
+    layer0_right_top,
+    layer1_right_top,
+    layer2_right_top,
+    layer3_right_top
 );
 
 void keyboard_post_init_user(void) {
-    rgblight_layers = my_rgb_layers;
+    rgblight_layers = layer_leds;
     rgblight_set_layer_state(0, true);
     rgblight_set_layer_state(4, true);
 }


### PR DESCRIPTION
## 概要

hadayan0 の Keyball61 keymap に、現在のレイヤーに応じて上面LEDの色を切り替える機能を追加します。

このPRでは、左右それぞれの上面LEDを対象に RGBLIGHT layer を定義し、アクティブなレイヤーに応じて暗めの色で点灯するようにします。

## 仕様

レイヤーごとの表示色は以下です。

- Layer 0: シアン
- Layer 1: 赤
- Layer 2: 黄
- Layer 3: 紫

対象LED範囲は、実機確認済みの以下を使用します。

- 左上面LED: `0, 29`
- 右上面LED: `44, 27`

色は明るすぎないように、通常の `HSV_CYAN` などではなく暗めの HSV 値を使います。

## 実装内容

- `RGBLIGHT_LAYERS` を有効化
- hadayan0 keymap にレイヤー別の RGBLIGHT segment を追加
- `keyboard_post_init_user()` で RGBLIGHT layer を登録
- `layer_state_set_user()` で現在レイヤーに応じて左右のLED layer stateを更新
- LED layer 固有の定義・処理は `RGBLIGHT_LAYERS` でガードし、将来 `layer_state_set_user()` にLED以外の処理を追加しても影響しにくい構成にする
- split layout 調整後に `rgblight_set()` を呼び、右ball側を master にした起動直後の初期色崩れを修正

## 動作確認

- `make keyball/keyball61:hadayan0` が成功することを確認
- 実機でレイヤー変更に応じてLED色が切り替わることを確認
- 左 no-ball 側 master で上面LEDが期待どおり切り替わることを確認
- 右 ball 側 master の起動直後に初期色が崩れないことを確認

## 補足

ビルド時にファームウェアサイズ警告が出ます。

- `27886/28672`
- 残り `786 bytes`

Closes #16