### PR TITLE
fix: 右master時のOLED表示向きを修正

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
+++ b/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
@@ -55,7 +55,7 @@ __attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) {
     //
     // Additionally, by rotating it, the left side of the logo will be above
     // the OLED screen, giving it a natural look.
-    return !is_keyboard_master() ? OLED_ROTATION_180 : rotation;
+    return !is_keyboard_left() ? OLED_ROTATION_180 : rotation;
 }
 
 #endif // OLED_ENABLE

--- a/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
+++ b/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
@@ -23,6 +23,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 __attribute__((weak)) void oledkit_render_logo_user(void) {
     // Require `OLED_FONT_H "keyboards/keyball/lib/logofont/logofont.c"`
     char ch = 0x80;
+    if (!is_keyboard_master() && is_keyboard_left()) {
+        oled_advance_page(false);
+    }
     for (int y = 0; y < 3; y++) {
         oled_write_P(PSTR("  "), false);
         for (int x = 0; x < 16; x++) {


### PR DESCRIPTION
## 概要

Issue #24 の対応として、OLEDの回転判定を master/secondary 基準から物理的な左右基準に変更します。

右側を master として使う場合でも、右側OLEDが正しい向きで表示されるようにします。

Closes #24

## 変更内容

- `oled_init_user()` の回転条件を `!is_keyboard_master()` から `!is_keyboard_left()` に変更
- 物理的に右側のOLEDは master/secondary に関係なく `OLED_ROTATION_180` を返す
- 左側のOLEDは既存の `rotation` をそのまま使う
- 右側を master にしたとき、secondary 側に表示されるロゴが上寄りにならないように表示開始位置を調整

## 動作確認

- ビルド確認

```text
make keyball/keyball61:hadayan0
```

```text
OK
28346/28672 bytes
326 bytes free
```

## 補足

この変更により、OLEDの向きは接続側ではなくキーボードの物理的な左右で決まります。あわせて、右側 master 時の secondary ロゴ表示位置も調整しています。
