### PR TITLE
底面LED向けのRGB効果を追加

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -21,22 +21,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #ifdef RGBLIGHT_ENABLE
-//#    define RGBLIGHT_EFFECT_BREATHING
+#    define RGBLIGHT_EFFECT_BREATHING
 //#    define RGBLIGHT_EFFECT_RAINBOW_MOOD
-//#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
 //#    define RGBLIGHT_EFFECT_SNAKE
 //#    define RGBLIGHT_EFFECT_KNIGHT
 //#    define RGBLIGHT_EFFECT_CHRISTMAS
-#    define RGBLIGHT_EFFECT_STATIC_GRADIENT
-#    define RGBLIGHT_LAYERS
+//#    define RGBLIGHT_EFFECT_STATIC_GRADIENT
 //#    define RGBLIGHT_EFFECT_RGB_TEST
 //#    define RGBLIGHT_EFFECT_ALTERNATING
-//#    define RGBLIGHT_EFFECT_TWINKLE
+#    define RGBLIGHT_EFFECT_TWINKLE
+
+// レイヤーごとに上面LEDの色を上書きする。
+#    define RGBLIGHT_LAYERS
 #endif
 
 #define TAP_CODE_DELAY 5
 
 #define KEYBALL_AUTO_SCROLLSNAP_ENABLE 1
 
-#define POINTING_DEVICE_AUTO_MOUSE_ENABLE
+//#define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 2
+
+// ファーム容量削減のため、ワンショットキー(OSM/OSL)を無効化する。
+// RemapでOSM/OSLを使う場合は、この定義をコメントアウトする。
+//#define NO_ACTION_ONESHOT


### PR DESCRIPTION
## 概要

Issue #26 の対応として、hadayan0 keymapで底面LED向けに利用するRGBアニメーション効果を有効化します。

有効化するRGB効果:

- Breathing
- Rainbow Swirl
- Twinkle

あわせて、上面LEDのレイヤー色上書きに使う `RGBLIGHT_LAYERS` はRGB効果定義とは性質が異なるため、設定上の記載位置を分離します。

## 容量調整

有効化するRGB効果を増やすため、未使用のAuto Mouseを無効化します。

`ALTERNATING` と `STATIC_GRADIENT` は今回利用しない想定のため無効化します。

ワンショットキー(OSM/OSL)はRemapで利用する可能性があるため、有効なまま残します。

## 動作確認

- `make keyball/keyball61:hadayan0`
- ビルドサイズ: `28670/28672 bytes`

Refs #26
