### PR TITLE
ブランチ運用ルールを追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## 概要
+
+
+## 動作確認
+
+
+## マージ時の注意
+
+- `develop` 向けPRは、必要に応じてSquash mergeを使ってよい
+- `main` 向けリリースPRは、Squash mergeを使わず `Create a merge commit` を選ぶ

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+このリポジトリでは、通常開発用の `develop` とリリース用の `main` を分けて運用します。
+
+## ブランチ運用
+
+- `develop`: 通常の開発ブランチ
+- `main`: リリースブランチ
+
+機能追加・修正は原則として `develop` に取り込みます。
+
+リリース時は `develop` から `main` へPull Requestを作成します。
+
+## Pull Requestのマージ方針
+
+通常の機能追加・修正PRを `develop` に取り込む場合は、必要に応じてSquash mergeを使って構いません。
+
+一方で、`develop` から `main` へ反映するリリースPRでは、Squash mergeを使いません。
+
+GitHub UIでリリースPRをマージする場合は、`Create a merge commit` を選択します。
+
+## 理由
+
+`develop` から `main` へのリリースPRをSquash mergeすると、`develop` 上の複数コミットが `main` 上の別の1コミットに潰されます。
+
+その結果、Gitの履歴上は `develop` のコミットが `main` に取り込まれていないように見え、次回リリース時に不要なコンフリクトが発生しやすくなります。
+
+`Create a merge commit` を使うと、`main` のマージコミットが `develop` 側の履歴を親として持つため、`develop` の内容が `main` に取り込まれたことをGitが追跡できます。
+
+## リリース後の確認
+
+`main` へのマージ後は、以下を確認します。
+
+- 関連Issueが意図どおりクローズされていること
+- 必要なリリースタグが作成されていること
+- `main` と `develop` の履歴が不要に分岐していないこと


### PR DESCRIPTION
## 概要

ブランチ運用とPRマージ方針をリポジトリ内に明文化します。

## 追加内容

- `CONTRIBUTING.md` に `develop` / `main` の役割を記載
- `develop -> main` のリリースPRではSquash mergeを使わず、`Create a merge commit` を選ぶ方針を記載
- PRテンプレートにマージ時の注意を追加

## 動作確認

- ドキュメント追加のみのため、ビルドは未実施
