### PR TITLE
Windows向け音量・ミュートキーを有効化する

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -21,9 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #ifdef RGBLIGHT_ENABLE
-#    define RGBLIGHT_EFFECT_BREATHING
+//#    define RGBLIGHT_EFFECT_BREATHING
 //#    define RGBLIGHT_EFFECT_RAINBOW_MOOD
-#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+//#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
 //#    define RGBLIGHT_EFFECT_SNAKE
 //#    define RGBLIGHT_EFFECT_KNIGHT
 //#    define RGBLIGHT_EFFECT_CHRISTMAS
@@ -45,4 +45,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // ファーム容量削減のため、ワンショットキー(OSM/OSL)を無効化する。
 // RemapでOSM/OSLを使う場合は、この定義をコメントアウトする。
-//#define NO_ACTION_ONESHOT
+#define NO_ACTION_ONESHOT

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/rules.mk
@@ -3,3 +3,6 @@ RGBLIGHT_ENABLE = yes
 OLED_ENABLE = yes
 
 VIA_ENABLE = yes
+
+# Remapで割り当てる音量・ミュートキーをWindowsへ送信する。
+EXTRAKEY_ENABLE = yes


### PR DESCRIPTION
## 概要

Remapで割り当てる音量・ミュートキーをWindowsへ送信できるように、hadayan0 keymapでExtraKeyを有効化しました。

## 変更内容

- `EXTRAKEY_ENABLE = yes` をhadayan0 keymapの `rules.mk` に追加
- ファーム容量確保のため、RGBエフェクトの `BREATHING` と `RAINBOW_SWIRL` を無効化
- ファーム容量確保のため、One Shotキー機能を無効化

## 影響

- Remapの `Mute` / `Vol-` / `Vol+` がConsumer Controlとして送信されるようになります
- RGBエフェクトの `TWINKLE` は維持しています
- RemapでOSM/OSLを使う場合は、`NO_ACTION_ONESHOT` の見直しが必要です

## 動作確認

- `make keyball/keyball61:hadayan0`
  - 成功
  - Firmware size: `28202/28672` bytes, `470` bytes free

Refs #35
