### PR TITLE
hadayan0-build 2026/06/07版

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Keyball61向けに `hadayan0` keymapを追加しています。
 - VIA / Remap対応
 - OLED表示
 - RGBLIGHT
+- 音量・ミュートキー対応
 
 また、RGB制御、CPI変更、スクロール設定、Keyball設定の保存/リセット用キーを配置しています。
 
@@ -83,13 +84,19 @@ Remapで設定したRGB制御キーから、RGBアニメーション効果を利
 
 有効化している効果は以下です。
 
-- Breathing
-- Rainbow Swirl
 - Twinkle
 
 上面LEDはレイヤー色切り替えを優先するため、RGBアニメーションは主に底面LEDで見える想定です。
 
 関連PR: [#30 底面LED向けのRGB効果を追加](https://github.com/hadayan0/keyball/pull/30)
+
+### 音量・ミュートキー対応
+
+Remapで割り当てた `Mute` / `Vol-` / `Vol+` がWindowsへ送信できるように、`EXTRAKEY_ENABLE` を有効化しています。
+
+ファーム容量確保のため、One Shotキー機能は無効化しています。Remapで `OSM` / `OSL` を使う場合は、`NO_ACTION_ONESHOT` の見直しが必要です。
+
+関連PR: [#36 Windows向け音量・ミュートキーを有効化する](https://github.com/hadayan0/keyball/pull/36)
 
 ### スクロール操作
 

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -21,9 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #ifdef RGBLIGHT_ENABLE
-#    define RGBLIGHT_EFFECT_BREATHING
+//#    define RGBLIGHT_EFFECT_BREATHING
 //#    define RGBLIGHT_EFFECT_RAINBOW_MOOD
-#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+//#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
 //#    define RGBLIGHT_EFFECT_SNAKE
 //#    define RGBLIGHT_EFFECT_KNIGHT
 //#    define RGBLIGHT_EFFECT_CHRISTMAS
@@ -45,4 +45,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // ファーム容量削減のため、ワンショットキー(OSM/OSL)を無効化する。
 // RemapでOSM/OSLを使う場合は、この定義をコメントアウトする。
-//#define NO_ACTION_ONESHOT
+#define NO_ACTION_ONESHOT

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/rules.mk
@@ -3,3 +3,6 @@ RGBLIGHT_ENABLE = yes
 OLED_ENABLE = yes
 
 VIA_ENABLE = yes
+
+# Remapで割り当てる音量・ミュートキーをWindowsへ送信する。
+EXTRAKEY_ENABLE = yes

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/rules.mk
@@ -1,8 +1,63 @@
+# レイヤー状態やモード状態をLED色で確認できるようにする。
 RGBLIGHT_ENABLE = yes
 
+# OLEDにレイヤー、スクロール状態、CPIなどの状態情報を表示する。
 OLED_ENABLE = yes
 
+# Remap/VIAでキーマップをブラウザから変更できるようにする。
 VIA_ENABLE = yes
 
 # Remapで割り当てる音量・ミュートキーをWindowsへ送信する。
 EXTRAKEY_ENABLE = yes
+
+# 追加で有効化を検討できるQMK機能。
+# 必要な行だけコメントアウトを解除して有効化する。
+# hadayan0はファーム容量が厳しいため、有効化後は必ずビルドサイズを確認する。
+
+# キー操作でマウスカーソル移動、クリック、ホイール操作を行う。
+# トラックボールとは別に、キーだけでマウス操作したい場合に使う。
+#MOUSEKEY_ENABLE = yes
+
+# Nキーロールオーバーを有効化する。
+# 多数キーの同時押しを安定して扱いたい場合に使う。
+#NKRO_ENABLE = yes
+
+# 起動時のキー操作でEEPROM設定変更やリセットを行う。
+# トラブル対応には便利だが、誤操作で設定が変わると原因追跡が難しくなる。
+#BOOTMAGIC_ENABLE = yes
+
+# hid_listenなどでファーム内のデバッグログをPCへ出力する。
+# 不具合調査には有用だが、ファーム容量を大きく消費する。
+#CONSOLE_ENABLE = yes
+
+# QMKのマジックコマンドを有効化する。
+# デバッグ切替やNKRO切替などに使えるが、常用では誤操作と容量増に注意する。
+#COMMAND_ENABLE = yes
+
+# Shift単押しで括弧、長押しでShiftのようなSpace Cadet系キーを使う。
+# 括弧入力を高速化したい場合に検討する。
+#SPACE_CADET_ENABLE = yes
+
+# Escと ` / ~ を兼ねるGrave Escape系キーを使う。
+# 小型キーボードでキー数を節約したい場合に検討する。
+#GRAVE_ESC_ENABLE = yes
+
+# EEPROMリセットなどのMagic keycodeを使う。
+# Remap中心の運用では必須ではないが、トラブル対応用キーを置きたい場合に検討する。
+#MAGIC_ENABLE = yes
+
+# 音を鳴らすQMK Audio機能を使う。
+# Keyball61では通常不要で、ハードウェア構成と容量面の確認が必要。
+#AUDIO_ENABLE = yes
+
+# キースイッチ側の単色バックライトを使う。
+# KeyballのRGB LED制御とは別機能。
+#BACKLIGHT_ENABLE = yes
+
+# PCスリープ中にLEDをブレス点灯させる。
+# Keyball61本体側でタイマー競合の注意があるため、基本的には有効化しない。
+#SLEEP_LED_ENABLE = yes
+
+# RGB Matrix機能を使う。
+# Keyball61ではRGBLIGHT側を使っており、現状は基本的に有効化しない。
+#RGB_MATRIX_ENABLE = yes


### PR DESCRIPTION
## 概要

`develop` の変更を `main` に反映します。

## 取り込み内容

- Remapで割り当てた `Mute` / `Vol-` / `Vol+` をWindowsへ送信できるように、hadayan0 keymapで `EXTRAKEY_ENABLE` を有効化
- ファーム容量確保のため、RGB効果の `BREATHING` / `RAINBOW_SWIRL` とOne Shotキー機能を無効化
- QMK機能オプションの用途説明を `rules.mk` にコメントとして追加
- READMEにExtraKey対応後の利用者向け差分を反映

## 動作確認

- `make keyball/keyball61:hadayan0`
  - 成功
  - Firmware size: `28202/28672` bytes, `470` bytes free

## マージ時の注意

このPRは `develop` から `main` へのリリースPRです。
ブランチ履歴を保つため、GitHubでは `Squash and merge` ではなく `Create a merge commit` を選択してください。

Closes #35
