### PR TITLE
Keyballの高解像度スクロールを有効化する

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -38,8 +38,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAP_CODE_DELAY 5
 
-#define POINTING_DEVICE_HIRES_SCROLL_ENABLE
-#define WHEEL_EXTENDED_REPORT
+// 高解像度スクロールを有効化する場合は、以下2つをコメントアウト解除する。
+// その場合、QMK 0.22.14 に高解像度スクロール対応をbackportした
+// hadayan0/qmk_firmware の branch を使用する必要がある。
+//#define POINTING_DEVICE_HIRES_SCROLL_ENABLE
+//#define WHEEL_EXTENDED_REPORT
 
 #define KEYBALL_AUTO_SCROLLSNAP_ENABLE 1
 

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -38,6 +38,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAP_CODE_DELAY 5
 
+#define POINTING_DEVICE_HIRES_SCROLL_ENABLE
+#define WHEEL_EXTENDED_REPORT
+
 #define KEYBALL_AUTO_SCROLLSNAP_ENABLE 1
 
 //#define POINTING_DEVICE_AUTO_MOUSE_ENABLE

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -40,7 +40,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // 高解像度スクロールを有効化する場合は、以下2つをコメントアウト解除する。
 // その場合、QMK 0.22.14 に高解像度スクロール対応をbackportした
-// hadayan0/qmk_firmware の branch を使用する必要がある。
+// hadayan0/qmk_firmware の `hadayan0/hires-scroll-backport-0.22.14`
+// branch を使用する必要がある。
 //#define POINTING_DEVICE_HIRES_SCROLL_ENABLE
 //#define WHEEL_EXTENDED_REPORT
 

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -75,7 +75,7 @@ static int16_t add16(int16_t a, int16_t b) {
 
 // divmod16 divides *v by div, returns the quotient, and assigns the remainder
 // to *v.
-static int16_t divmod16(int16_t *v, int16_t div) {
+static __attribute__((unused)) int16_t divmod16(int16_t *v, int16_t div) {
     int16_t r = *v / div;
     *v -= r * div;
     return r;
@@ -86,8 +86,29 @@ static inline int8_t clip2int8(int16_t v) {
     return (v) < -127 ? -127 : (v) > 127 ? 127 : (int8_t)v;
 }
 
+static inline mouse_hv_report_t clip2mouse_hv(int32_t v) {
+#ifdef WHEEL_EXTENDED_REPORT
+    return v < -32767 ? -32767 : v > 32767 ? 32767 : (mouse_hv_report_t)v;
+#else
+    return clip2int8(v);
+#endif
+}
+
+static mouse_hv_report_t divmod16_scroll(int16_t *v, int16_t div) {
+#ifdef POINTING_DEVICE_HIRES_SCROLL_ENABLE
+    uint16_t resolution = pointing_device_get_hires_scroll_resolution();
+    int32_t  scaled     = (int32_t)*v * resolution;
+    int32_t  quotient   = scaled / div;
+    int32_t  remainder  = scaled % div;
+    *v                  = remainder / resolution;
+    return clip2mouse_hv(quotient);
+#else
+    return clip2mouse_hv(divmod16(v, div));
+#endif
+}
+
 #ifdef OLED_ENABLE
-static const char *format_4d(int8_t d) {
+static const char *format_4d(int16_t d) {
     static char buf[5] = {0}; // max width (4) + NUL (1)
     char        lead   = ' ';
     if (d < 0) {
@@ -188,20 +209,20 @@ __attribute__((weak)) void keyball_on_apply_motion_to_mouse_move(keyball_motion_
 __attribute__((weak)) void keyball_on_apply_motion_to_mouse_scroll(keyball_motion_t *m, report_mouse_t *r, bool is_left) {
     // consume motion of trackball.
     int16_t div = 1 << (keyball_get_scroll_div() - 1);
-    int16_t x = divmod16(&m->x, div);
-    int16_t y = divmod16(&m->y, div);
+    mouse_hv_report_t x = divmod16_scroll(&m->x, div);
+    mouse_hv_report_t y = divmod16_scroll(&m->y, div);
 
     // apply to mouse report.
 #if KEYBALL_MODEL == 61 || KEYBALL_MODEL == 39 || KEYBALL_MODEL == 147 || KEYBALL_MODEL == 44
-    r->h = clip2int8(y);
-    r->v = -clip2int8(x);
+    r->h = y;
+    r->v = -x;
     if (is_left) {
         r->h = -r->h;
         r->v = -r->v;
     }
 #elif KEYBALL_MODEL == 46
-    r->h = clip2int8(x);
-    r->v = clip2int8(y);
+    r->h = x;
+    r->v = y;
 #else
 #    error("unknown Keyball model")
 #endif

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -86,24 +86,30 @@ static inline int8_t clip2int8(int16_t v) {
     return (v) < -127 ? -127 : (v) > 127 ? 127 : (int8_t)v;
 }
 
-static inline mouse_hv_report_t clip2mouse_hv(int32_t v) {
 #ifdef WHEEL_EXTENDED_REPORT
-    return v < -32767 ? -32767 : v > 32767 ? 32767 : (mouse_hv_report_t)v;
+typedef mouse_hv_report_t keyball_scroll_report_t;
+#else
+typedef int8_t keyball_scroll_report_t;
+#endif
+
+static inline keyball_scroll_report_t clip2scroll_report(int32_t v) {
+#ifdef WHEEL_EXTENDED_REPORT
+    return v < -32767 ? -32767 : v > 32767 ? 32767 : (keyball_scroll_report_t)v;
 #else
     return clip2int8(v);
 #endif
 }
 
-static mouse_hv_report_t divmod16_scroll(int16_t *v, int16_t div) {
+static keyball_scroll_report_t divmod16_scroll(int16_t *v, int16_t div) {
 #ifdef POINTING_DEVICE_HIRES_SCROLL_ENABLE
     uint16_t resolution = pointing_device_get_hires_scroll_resolution();
     int32_t  scaled     = (int32_t)*v * resolution;
     int32_t  quotient   = scaled / div;
     int32_t  remainder  = scaled % div;
     *v                  = remainder / resolution;
-    return clip2mouse_hv(quotient);
+    return clip2scroll_report(quotient);
 #else
-    return clip2mouse_hv(divmod16(v, div));
+    return clip2scroll_report(divmod16(v, div));
 #endif
 }
 
@@ -209,8 +215,8 @@ __attribute__((weak)) void keyball_on_apply_motion_to_mouse_move(keyball_motion_
 __attribute__((weak)) void keyball_on_apply_motion_to_mouse_scroll(keyball_motion_t *m, report_mouse_t *r, bool is_left) {
     // consume motion of trackball.
     int16_t div = 1 << (keyball_get_scroll_div() - 1);
-    mouse_hv_report_t x = divmod16_scroll(&m->x, div);
-    mouse_hv_report_t y = divmod16_scroll(&m->y, div);
+    keyball_scroll_report_t x = divmod16_scroll(&m->x, div);
+    keyball_scroll_report_t y = divmod16_scroll(&m->y, div);
 
     // apply to mouse report.
 #if KEYBALL_MODEL == 61 || KEYBALL_MODEL == 39 || KEYBALL_MODEL == 147 || KEYBALL_MODEL == 44

--- a/qmk_firmware/keyboards/keyball/readme.md
+++ b/qmk_firmware/keyboards/keyball/readme.md
@@ -40,6 +40,10 @@ See each directories for each keyboards in a table above.
     `keyball61/keymaps/hadayan0/config.h`, and use the QMK fork branch below
     because it backports the required support to QMK 0.22.14.
 
+    This branch is a long-lived `0.22.14` backport branch for the `hadayan0`
+    keymap. It is not intended to be merged into QMK `master`; the related
+    QMK pull request is kept as a draft for diff/reference purposes.
+
     ```console
     $ git clone https://github.com/hadayan0/qmk_firmware.git --depth 1 --recurse-submodules --shallow-submodules -b hadayan0/hires-scroll-backport-0.22.14 qmk
     ```

--- a/qmk_firmware/keyboards/keyball/readme.md
+++ b/qmk_firmware/keyboards/keyball/readme.md
@@ -32,8 +32,13 @@ See each directories for each keyboards in a table above.
 
     Currently Keyball firmwares are verified to compile with QMK 0.22.14
 
-    For the `hadayan0` keymap, use the QMK fork branch below because it
-    backports high resolution scrolling support to QMK 0.22.14.
+    The `hadayan0` keymap can be built with the QMK 0.22.14 command above
+    while high resolution scrolling is disabled.
+
+    To enable high resolution scrolling for the `hadayan0` keymap, uncomment
+    `POINTING_DEVICE_HIRES_SCROLL_ENABLE` and `WHEEL_EXTENDED_REPORT` in
+    `keyball61/keymaps/hadayan0/config.h`, and use the QMK fork branch below
+    because it backports the required support to QMK 0.22.14.
 
     ```console
     $ git clone https://github.com/hadayan0/qmk_firmware.git --depth 1 --recurse-submodules --shallow-submodules -b hadayan0/hires-scroll-backport-0.22.14 qmk

--- a/qmk_firmware/keyboards/keyball/readme.md
+++ b/qmk_firmware/keyboards/keyball/readme.md
@@ -32,6 +32,13 @@ See each directories for each keyboards in a table above.
 
     Currently Keyball firmwares are verified to compile with QMK 0.22.14
 
+    For the `hadayan0` keymap, use the QMK fork branch below because it
+    backports high resolution scrolling support to QMK 0.22.14.
+
+    ```console
+    $ git clone https://github.com/hadayan0/qmk_firmware.git --depth 1 --recurse-submodules --shallow-submodules -b hadayan0/hires-scroll-backport-0.22.14 qmk
+    ```
+
 3. Create a symbolic link to this `keyball/` directory from [qmk/qmk_firmware]'s `keyboards/` directory.
 
     ```console


### PR DESCRIPTION
## 概要

hadayan0 keymapでKeyballの高解像度スクロールを利用できるようにします。

通常状態では高解像度スクロール設定を無効にしておき、QMK 0.22.14のままビルドできる互換性を維持します。高解像度スクロールを使う場合は、hadayan0 keymapの設定を明示的に有効化し、QMK fork branchを使用します。

## 変更内容

- Keyballのスクロール変換を高解像度ホイール向けに対応
  - `POINTING_DEVICE_HIRES_SCROLL_ENABLE` 有効時は `raw motion * resolution / divider` で細かいwheel tickを送信
  - 無効時は従来のdivider処理を維持
- scroll reportの型を設定に応じて切り替える互換型を追加
  - 通常QMKでは従来通り `int8_t`
  - `WHEEL_EXTENDED_REPORT` 有効時はQMK fork側の拡張型
- hadayan0 keymapでは高解像度スクロール設定をコメントアウト状態で記載
  - developへ入れても通常QMK 0.22.14でビルド可能
  - 利用時だけコメントアウト解除するopt-in運用
- READMEに通常QMKでのビルド可否と、高解像度スクロールを使う場合のQMK fork branch手順を追記

## QMK依存

高解像度スクロールを有効化する場合は、QMK 0.22.14へ高解像度スクロールをbackportした以下のfork branchを使用します。

- https://github.com/hadayan0/qmk_firmware/tree/hadayan0/hires-scroll-backport-0.22.14

QMK側backport commit:

- `3a11cf54 Backport high resolution scroll support`

## 動作確認

- 通常QMK 0.22.14相当、設定OFF
  - `make keyball/keyball61:hadayan0`
  - 成功
  - Firmware size: `28226/28672` bytes, `446` bytes free
- QMK fork branch、設定OFF
  - `make keyball/keyball61:hadayan0`
  - 成功
  - Firmware size: `28226/28672` bytes, `446` bytes free
- QMK fork branch、設定ON
  - `make keyball/keyball61:hadayan0`
  - 成功
  - Firmware size: `28462/28672` bytes, `210` bytes free
- 実機確認
  - Windows環境で高解像度スクロール有効時のスクロールに違和感がないことを確認

## 注意点

- 高解像度スクロールを有効化する場合は、QMK fork branchが必要です
- 通常QMK 0.22.14を使う場合は、`POINTING_DEVICE_HIRES_SCROLL_ENABLE` / `WHEEL_EXTENDED_REPORT` をコメントアウトしたままにします
- 高解像度スクロールの体感はアプリ側の対応状況に依存する可能性があります

Refs #39
