### PR TITLE
Scrollsnap調整値の既定値を微調整し、keymap側に調整入口を明示

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/hadayan0/config.h
@@ -39,6 +39,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAP_CODE_DELAY 5
 
 #define KEYBALL_AUTO_SCROLLSNAP_ENABLE 1
+// 利用者ごとに好みが分かれるため、斜めスクロール判定の調整値は
+// keymap側で上書きしておく。現時点ではライブラリ既定値と同じ。
+// スクロール入力が止まったあと、どれだけ経ったら判定状態をリセットするか(ms)。
+#define KEYBALL_AUTO_SCROLLSNAP_RESET_TIMER 300
+// 縦/横どちらかに寄っていると確定するまでの時間(ms)。小さいほど斜めスクロールになりづらい。
+#define KEYBALL_AUTO_SCROLLSNAP_CONFIRM_TIMER 10
+// 縦/横どちらかに寄っていると見なす比率。大きいほど斜め扱いになりやすく、小さいほど縦横固定しやすい。
+#define KEYBALL_AUTO_SCROLLSNAP_RATIO 2
 
 //#define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 2

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #ifndef KEYBALL_AUTO_SCROLLSNAP_CONFIRM_TIMER
-#    define KEYBALL_AUTO_SCROLLSNAP_CONFIRM_TIMER 12
+#    define KEYBALL_AUTO_SCROLLSNAP_CONFIRM_TIMER 10
 #endif
 
 #ifndef KEYBALL_AUTO_SCROLLSNAP_RATIO


### PR DESCRIPTION
## 概要

スクロールの自動スナップ判定について、既定値の微調整と、keymap 側での調整入口の明示を行います。

## 変更内容

- `KEYBALL_AUTO_SCROLLSNAP_CONFIRM_TIMER` の既定値を `12` から `10` へ調整
- `hadayan0` keymap の `config.h` に以下の調整パラメータを明示
  - `KEYBALL_AUTO_SCROLLSNAP_RESET_TIMER`
  - `KEYBALL_AUTO_SCROLLSNAP_CONFIRM_TIMER`
  - `KEYBALL_AUTO_SCROLLSNAP_RATIO`
- 各パラメータについて、役割と調整方向が分かるコメントを追加

## 意図

- auto scrollsnap の挙動は利用者ごとに好みが分かれるため、ライブラリ既定値だけでなく keymap 側にも調整入口を置いておく
- 今後の調整時に、どの定数を触るべきかを見つけやすくする
